### PR TITLE
Encountered a bug that caused some NIfTI data to not load correctly w…

### DIFF
--- a/fileIO/GPI/ReadNiBabel_GPI.py
+++ b/fileIO/GPI/ReadNiBabel_GPI.py
@@ -47,9 +47,9 @@ class ExternalNode(gpi.NodeAPI):
 
         nibabel_image = nib.load(fname)
 
-        out_data = nibabel_image.get_data()
+        out_data = np.ascontiguousarray(nibabel_image.get_data())
         if self.getVal('reverse-dims'):
-            out_data = out_data.T
+            out_data = np.ascontiguousarray(out_data.T)
 
         self.setData('image', out_data)
         self.setData('affine', nibabel_image.affine)

--- a/fileIO/GPI/WriteNiBabel_GPI.py
+++ b/fileIO/GPI/WriteNiBabel_GPI.py
@@ -31,7 +31,7 @@ class ExternalNode(gpi.NodeAPI):
         self.addWidget('SaveFileBrowser', 'output-file', button_title='Browse',
                        caption='Save File')
         self.addWidget('ComboBox', 'file-type',
-                       items=file_types.keys(), val='nifti1')
+                       items=list(file_types.keys()), val='nifti1')
         self.addWidget('PushButton', 'reverse-dims',
                        toggle=True, val=False, collapsed=True) 
 


### PR DESCRIPTION
Hi Ashley,

I started using this project to read and write NIfTI data. I came across an issue on my MacBook where the images read by ReadNiBabel would be incoherent. I found out that this could be fixed by forcing data contiguity using numpy.ascontiguousarray(). I also found that WriteNiBabel was crashing on init. It wasn't liking the use of dictionary keys as a widget parameter value. I just recast the keys as a list to fix the bug.

Let me know if you have a different fix for these issues.